### PR TITLE
Use the correct checksum field name

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/DynamoFormatters.scala
+++ b/src/main/scala/uk/gov/nationalarchives/DynamoFormatters.scala
@@ -22,7 +22,7 @@ object DynamoFormatters {
   val parentPath = "parentPath"
   val title = "title"
   val description = "description"
-  val checksumSha256 = "checksumSha256"
+  val checksumSha256 = "checksum_sha256"
   val fileExtension = "fileExtension"
 
   private type InvalidProperty = (String, DynamoReadError)

--- a/src/test/scala/uk/gov/nationalarchives/DynamoFormattersTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/DynamoFormattersTest.scala
@@ -155,7 +155,7 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
     resultMap(description).s() should equal(description)
     resultMap(sortOrder).n() should equal("1")
     resultMap(fileSize).n() should equal("2")
-    resultMap(checksumSha256).s() should equal("checksumSha256")
+    resultMap(checksumSha256).s() should equal("checksum_sha256")
     resultMap(fileExtension).s() should equal(fileExtension)
     resultMap("id_Test1").s() should equal("Value1")
     resultMap("id_Test2").s() should equal("Value2")


### PR DESCRIPTION
The field name is checksum_sha256. Because this is an optional field,
the formatter is returning empty string. This should fix it.
