### PR TITLE
Revert "DR2 1598 update ingest lock table with new fields"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ Their identifierName will be prefixed with id_ and used as the field name
 The formatter will report all errors with a particular Dynamo row.
 
 ## Lock table
-This holds a lock with an asset ID, a message ID, the parentMessage ID and the execution ID.
+This holds a lock with an information object ID, a batch id and the message to be processed.
 ### Validation
 #### Mandatory fields
 These fields must always be present
-* assetId (UUID)
-* messageId (UUID)
+* ioId (UUID)
+* batchId (String)
+* message (String)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.9.6

--- a/src/main/scala/uk/gov/nationalarchives/DynamoFormatters.scala
+++ b/src/main/scala/uk/gov/nationalarchives/DynamoFormatters.scala
@@ -58,7 +58,9 @@ object DynamoFormatters {
   }
 
   val batchId = "batchId"
+  val ioId = "ioId"
   val id = "id"
+  val message = "message"
   val name = "name"
   val typeField = "type"
   val fileSize = "fileSize"
@@ -77,11 +79,6 @@ object DynamoFormatters {
   val originalMetadataFiles = "originalMetadataFiles"
   val representationType = "representationType"
   val representationSuffix = "representationSuffix"
-
-  val assetId = "assetId"
-  val messageId = "messageId"
-  val parentMessageId = "parentMessageId"
-  val executionId = "executionId"
 
   given pkFormat: Typeclass[PartitionKey] = deriveDynamoFormat[PartitionKey]
 
@@ -102,10 +99,9 @@ object DynamoFormatters {
   private type ValidatedField[T] = ValidatedNel[(FieldName, DynamoReadError), T]
 
   case class LockTableValidatedFields(
-      assetId: ValidatedField[UUID], // We have not yet decided whether it's going to be Zref or UUID
-      messageId: ValidatedField[UUID],
-      parentMessageId: ValidatedField[Option[UUID]],
-      executionId: Option[String]
+      assetId: ValidatedField[UUID],
+      batchId: ValidatedField[String],
+      message: ValidatedField[String]
   )
 
   case class FilesTableValidatedFields(
@@ -193,7 +189,7 @@ object DynamoFormatters {
 
   case class PartitionKey(id: UUID)
 
-  case class IngestLockTable(assetId: UUID, messageId: UUID, parentMessageId: Option[UUID], executionId: Option[String])
+  case class IngestLockTable(ioId: UUID, batchId: String, message: String)
 
   enum FileRepresentationType:
     override def toString: String = this match

--- a/src/main/scala/uk/gov/nationalarchives/DynamoWriteUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/DynamoWriteUtils.scala
@@ -63,16 +63,10 @@ object DynamoWriteUtils {
 
   def writeLockTable(lockTable: IngestLockTable): DynamoValue =
     DynamoObject {
-      val optionalFields: Map[FieldName, DynamoValue] = Map(
-        "executionId" -> lockTable.executionId.map(id => DynamoValue.fromString(id)),
-        "parentMessageId" -> lockTable.parentMessageId.map(pid => DynamoValue.fromString(pid.toString))
-      ).flatMap {
-        case (fieldName, Some(value)) => Map(fieldName -> value)
-        case _                        => Map.empty
-      }
-      optionalFields ++ Map(
-        assetId -> DynamoValue.fromString(lockTable.assetId.toString),
-        messageId -> DynamoValue.fromString(lockTable.messageId.toString)
+      Map(
+        ioId -> DynamoValue.fromString(lockTable.ioId.toString),
+        batchId -> DynamoValue.fromString(lockTable.batchId),
+        message -> DynamoValue.fromString(lockTable.message)
       )
     }.toDynamoValue
 }

--- a/src/test/scala/uk/gov/nationalarchives/DynamoFormattersTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/DynamoFormattersTest.scala
@@ -5,11 +5,10 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers.*
 import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1, TableFor3}
-import org.scanamo
 import org.scanamo.*
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue.{fromL, fromM, fromN, fromS}
-import uk.gov.nationalarchives.DynamoFormatters.{*, given}
+import uk.gov.nationalarchives.DynamoFormatters.{given, *}
 import uk.gov.nationalarchives.DynamoFormatters.Type.*
 import uk.gov.nationalarchives.DynamoFormatters.FileRepresentationType.*
 
@@ -419,102 +418,42 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
   }
 
   "lockTable read" should "read the correct fields" in {
-    val assetId = UUID.randomUUID()
-    val parentMessageId = UUID.randomUUID()
-    val messageId = UUID.randomUUID()
-    val executionId = "executionId"
+    val ioId = UUID.randomUUID()
+    val batchId = "batchId"
+    val message = "{}"
 
     val input =
-      fromM(
-        Map(
-          "assetId" -> fromS(assetId.toString),
-          "parentMessageId" -> fromS(parentMessageId.toString),
-          "messageId" -> fromS(messageId.toString),
-          "executionId" -> fromS(executionId)
-        ).asJava
-      )
+      fromM(Map("ioId" -> fromS(ioId.toString), "batchId" -> fromS(batchId), "message" -> fromS(message)).asJava)
     val res = ingestLockTableFormat.read(input).value
-    res.assetId should equal(assetId)
-    res.parentMessageId should equal(Some(parentMessageId))
-    res.messageId should equal(messageId)
-    res.executionId should equal(Some(executionId))
+    res.ioId should equal(ioId)
+    res.batchId should equal(batchId)
+    res.message should equal(res.message)
   }
 
-  "lockTable read" should "return the error type 'MissingProperty' for each of the required fields, 'assetId' and 'messageId', " +
-    "if they are missing but not for the optional fields 'parentMessageId' and 'executionId'" in {
-      val input = fromM(Map("invalidField" -> fromS(UUID.randomUUID().toString)).asJava)
-      val res = ingestLockTableFormat.read(input)
-      val expectedMissingProperties = List(assetId, messageId)
+  "lockTable read" should "error if the field is missing" in {
+    val ioId = UUID.randomUUID()
 
-      val actualMissingProperties = res.left.value.asInstanceOf[InvalidPropertiesError].errors
-
-      val expectedPropertiesAreMissing = actualMissingProperties.forall {
-        case (name: String, a: MissingProperty.type) => expectedMissingProperties.contains(name)
-        case _                                       => false
-      }
-      res.isLeft should be(true)
-      actualMissingProperties.length should equal(2)
-      expectedPropertiesAreMissing should be(true)
-
-      val actualMissingPropertyNames = actualMissingProperties.map { case (name, _) => name }.toList
-      List("parentMessageId", "executionId").foreach { optionalProperty =>
-        actualMissingPropertyNames.contains(optionalProperty) should equal(false)
-      }
+    val input = fromM(Map("invalidField" -> fromS(ioId.toString)).asJava)
+    val res = ingestLockTableFormat.read(input)
+    res.isLeft should be(true)
+    val isMissingPropertyError = res.left.value.asInstanceOf[InvalidPropertiesError].errors.head._2 match {
+      case MissingProperty => true
+      case _               => false
     }
-
-  "lockTable read" should "return the values of 'None' for the optional properties 'parentMessageId' and 'executionId' " +
-    "if they are missing" in {
-      val assetId = UUID.randomUUID()
-      val parentMessageId = UUID.randomUUID()
-      val messageId = UUID.randomUUID()
-      val executionId = "executionId"
-
-      val input =
-        fromM(
-          Map(
-            "assetId" -> fromS(assetId.toString),
-            "messageId" -> fromS(messageId.toString)
-          ).asJava
-        )
-      val res = ingestLockTableFormat.read(input).value
-      res.assetId should equal(assetId)
-      res.parentMessageId should equal(None)
-      res.messageId should equal(messageId)
-      res.executionId should equal(None)
-    }
+    isMissingPropertyError should be(true)
+  }
 
   "lockTable write" should "write the correct fields" in {
-    val assetId = UUID.randomUUID()
-    val messageId = UUID.randomUUID()
-    val parentMessageId = UUID.randomUUID()
-    val executionId = "executionId"
+    val ioId = UUID.randomUUID()
+    val batchId = "batchId"
+    val message = "{}"
 
     val attributeValueMap =
-      ingestLockTableFormat
-        .write(IngestLockTable(assetId, messageId, Some(parentMessageId), Some(executionId)))
-        .toAttributeValue
-        .m()
-        .asScala
-
-    attributeValueMap("assetId").s() should equal(assetId.toString)
-    attributeValueMap("messageId").s() should equal(messageId.toString)
-    attributeValueMap("parentMessageId").s() should equal(parentMessageId.toString)
-    attributeValueMap("executionId").s() should equal(executionId)
+      ingestLockTableFormat.write(IngestLockTable(ioId, batchId, message)).toAttributeValue.m().asScala
+    UUID.fromString(attributeValueMap("ioId").s()) should equal(ioId)
+    attributeValueMap("batchId").s() should equal("batchId")
+    attributeValueMap("message").s() should equal("{}")
   }
-
-  "lockTable write" should "write only the required fields, 'assetId' and 'messageId' if the value of 'None' was given " +
-    "for 'parentMessageId' and 'executionId'" in {
-      val assetId = UUID.randomUUID()
-      val messageId = UUID.randomUUID()
-
-      val attributeValueMap =
-        ingestLockTableFormat.write(IngestLockTable(assetId, messageId, None, None)).toAttributeValue.m().asScala
-
-      attributeValueMap("assetId").s() should equal(assetId.toString)
-      attributeValueMap("messageId").s() should equal(messageId.toString)
-      attributeValueMap.get("parentMessageId").map(_.s()) should equal(None)
-      attributeValueMap.get("executionId").map(_.s()) should equal(None)
-    }
 
   private def generateListAttributeValue(values: String*): AttributeValue =
     fromL(


### PR DESCRIPTION
Reverts nationalarchives/dr2-dynamo-formatters#25. The original PR was due to a misunderstanding, so this undoes it.